### PR TITLE
Migrate from pip3 to uv for Python package management

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -106,7 +106,12 @@ GIT_BRANCH=${GIT_BRANCH:-$DEFAULT_GIT_BRANCH}
 
 info "📦 Updating package list & installing system packages..."
 apt update
-apt install -y git python3 python3-pip python3-smbus python3-rpi.gpio i2c-tools libgpiod-dev
+apt install -y git python3 python3-smbus python3-rpi.gpio i2c-tools libgpiod-dev curl
+
+# Install uv - fast Python package manager
+info "📦 Installing uv (fast Python package manager)..."
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.cargo/bin:$PATH"
 
 
 # Clone repository
@@ -125,8 +130,11 @@ cd "$APP_DIR"
 
 # Install Python dependencies
 if [ -f "./src/requirements.txt" ]; then
-    info "📦 Installing Python dependencies..."
-    sudo -u "$SUDO_USER" pip3 install --break-system-packages -r ./src/requirements.txt
+    info "📦 Installing Python dependencies with uv..."
+    # Ensure uv is available in the current shell
+    export PATH="$HOME/.cargo/bin:$PATH"
+    # Install dependencies using uv (faster and more reliable than pip)
+    sudo -u "$SUDO_USER" bash -c "export PATH=\"$HOME/.cargo/bin:\$PATH\"; uv pip install --system -r ./src/requirements.txt"
 else
     info "ℹ️ No requirements.txt found, skipping Python package installation."
 fi


### PR DESCRIPTION
## Summary
  Modernize Python package management by migrating from pip3 to uv, a fast Python package manager built in Rust.

  ## Changes
  - **Remove python3-pip** from system package dependencies
  - **Add curl** dependency for uv installation
  - **Install uv** using official installer script from astral.sh
  - **Replace pip3 command** with `uv pip install --system`
  - **Add proper PATH handling** to ensure uv availability during installation

  ## Benefits
  - **🚀 Significantly faster** package installation and dependency resolution
  - **🔒 More reliable** caching and installation process
  - **🔍 Better conflict detection** and resolution capabilities
  - **⚡ Modern tooling** with improved performance over traditional pip
  - **🔄 Drop-in compatibility** with existing requirements.txt format

  ## Technical Details
  - Uses `uv pip install --system` to maintain compatibility with system-wide installation
  - Preserves existing requirements.txt format - no changes needed to dependency specifications
  - Adds proper PATH export to ensure uv is available in all shell contexts
  - Falls back gracefully if requirements.txt is not found

  This modernization improves installation speed and reliability while maintaining full backward compatibility.